### PR TITLE
Use the project name in the require

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For now, next things are implemented:
 ## Example
 Here is classic 'Hello World' in Amethyst
 ```crystal
-require "amethyst"
+require "Amethyst/amethyst"
 
 class WorldController < Base::Controller
   actions :hello


### PR DESCRIPTION
Because of how Crystal's require works, the example wouldn't work if you're deploying it to Heroku, for instance (maybe there are other situations). 

As far as I could understand it depends on your system considering "Amethyst/amethyst.cr" to exist, when asking for "amethyst/amethyst.cr".

The other solution would be to rename the project to use a lowercase "A", since that's what Crystal is expecting, from what I can tell. Maybe @asterite can shed more light on the matter.
