### PR TITLE
Fixed up some grammar and fixed codcore link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Pledgie](https://pledgie.com/campaigns/29689.png?skin_name=chrome)](https://pledgie.com/campaigns/29689)
 [![Build Status](https://travis-ci.org/Codcore/amethyst.svg)](https://travis-ci.org/Codcore/amethyst)  [![Join the chat at https://gitter.im/Codcore/Amethyst](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Codcore/Amethyst?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Amethyst is a web framework written in [Crystal](https://github.com/manastech/crystal) language. The goals of Amethyst are to be extremely fast and provide agility in application development as Rails do. Why I called it "Amethyst"? Because Crystal  has a light purple color at GitHub like [amethyst gemstone](http://en.wikipedia.org/wiki/Amethyst).
+Amethyst is a web framework written in the [Crystal](https://github.com/manastech/crystal) language. The goals of Amethyst are to be extremely fast and to provide agility in application development, much like Rails. Why did I call it "Amethyst"? Because Github uses a light purple color for the Crystal language similar to the [amethyst gemstone](http://en.wikipedia.org/wiki/Amethyst).
 
 Latest version - [0.1.7](https://github.com/Codcore/Amethyst/releases/tag/v0.1.7)
 Note that Amethyst is at it early stages, so it lacks for whole bunch of things. But you can give a hand with contributing.
@@ -88,7 +88,7 @@ I would be glad for any help with contributing.
 
 ## Contributors
 
-- [Andrew Yaroshuk](https://github.com/Codcore]) Codcore - creator, maintainer
+- [Andrew Yaroshuk](https://github.com/Codcore) Codcore - creator, maintainer
 
 ## Support
 Amethyst is not a commercial project,it is developed on pure enthusiasm, so if you want to support Amethyst developing, you can help with donating.


### PR DESCRIPTION
I fixed up the grammar in some places and fixed the link to the codcore github profile. It had an extra ']' that prevented the link from going to the right place.
