### PR TITLE
add simple layout support

### DIFF
--- a/src/amethyst/sugar/view.cr
+++ b/src/amethyst/sugar/view.cr
@@ -24,4 +24,21 @@ module View
     _view = {{view_klass.id.capitalize}}View.new(controller=self)
     @response.body = _view.render
   end
+
+  macro layout(name, path=_DIR_)
+    class {{name.id.capitalize}}View < Base::View
+      def initialize(controller, view)
+        @controller = controller
+        @view = view
+      end
+      ecr_file "{{path.id}}/{{name.id}}.ecr"
+    end
+  end
+
+  macro render_with_layout(view_klass, layout_klass)
+    _view = {{view_klass.id.capitalize}}View.new(controller=self)
+    _layout = {{layout_klass.id.capitalize}}View.new(controller=self, view =
+                                                     _view.render)
+    @response.body = _layout.render
+  end
 end


### PR DESCRIPTION
added a layout macro and render_with_layout macro.  In order to pass the view
to the layout, I added a @view instance variable that holds the rendered view
and then placed that rendered view in the layout ECR by spitting out the @view
instance variable.

I couldn't figure out how to use <%= yield %> inside the ECR and pass a block
of the view to be rendered.  That would be great to solve.
