### PR TITLE
Enable pool_spec test

### DIFF
--- a/spec/session/pool_spec.cr
+++ b/spec/session/pool_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 
 describe Pool do
 
-  session_pool = Pool::INSTANCE 
+  session_pool = Pool::INSTANCE
 
   describe "#generate_sid" do
     it "should return a unique id" do
@@ -35,6 +35,5 @@ describe Pool do
         session_pool.get_session(sid)[:test]
       end
     end
-
   end
 end

--- a/src/amethyst/session/pool.cr
+++ b/src/amethyst/session/pool.cr
@@ -18,17 +18,17 @@ require "secure_random"
 
 class Pool
   property :pool
-  
+
   include Sugar::Klass
   singleton_INSTANCE
-  
+
   def initialize
     @pool = {} of String => Hash
   end
 
   def generate_sid
     sid = loop do
-      sid = Base64.urlsafe_encode64(SecureRandom.random_bytes(128))
+      sid = Base64.urlsafe_encode(SecureRandom.random_bytes(128))
       break sid unless @pool.has_key?(sid)
     end
     @pool[sid] = {} of Symbol => String


### PR DESCRIPTION
This pool_spec test failed, because Base64#urlsafe_encode method in 'src/amethyst/session/pool.cr' missed. typo(urlsafe_encode64) resulted in spec failure.
