### PR TITLE
fix syntax error, spacing between argument and type restriction

### DIFF
--- a/src/amethyst/support/controller_helpers.cr
+++ b/src/amethyst/support/controller_helpers.cr
@@ -16,7 +16,7 @@ module Amethyst
         @response.header("Content-Type", "application/json")
       end
 
-      private def json(body: Hash, status=200)
+      private def json(body : Hash, status=200)
         @response.set(status, body.to_json)
         @response.header("Content-Type", "application/json")
       end


### PR DESCRIPTION
to fix syntax error, added space between argument and type restriction same as other methods.
