### PR TITLE
Allow nested views, require spec_helper

### DIFF
--- a/spec/base/spec_helper.cr
+++ b/spec/base/spec_helper.cr
@@ -1,3 +1,4 @@
+require "../spec_helper"
 require "../../src/all"
 
 class ViewController < Controller

--- a/src/amethyst/sugar/view.cr
+++ b/src/amethyst/sugar/view.cr
@@ -17,6 +17,7 @@ module Amethyst
         class {{name.id.capitalize}}View < Base::View
           def initialize(controller)
             @controller = controller
+            @response = Http::Response.new
           end
           ecr_file "{{path.id}}/{{name.id}}.ecr"
         end


### PR DESCRIPTION
Making Views "pretend" they're Controllers so that they can be nested (e.g. to use as partials).
Also `require` the spec helper in the Application spec so that it can actually run.
