### PR TITLE
Fix Syntax error: space between named argument name and ':' on Crystal 0.23.1

### DIFF
--- a/src/amethyst/http/request.cr
+++ b/src/amethyst/http/request.cr
@@ -141,17 +141,17 @@ module Amethyst
       # Sets properties to log
       def log
         {
-          "http method"     : @method,
-          "path"            : path,
-          "query string"    : query_string.hash,
-          "protocol"        : protocol,
-          "host"            : host,
-          "port"            : port,
-          "version"         : @version,
-          "query params"    : query_parameters.hash,
-          "path parameters" : path_parameters.hash,
-          "post parameters" : request_parameters.hash,
-          "content type"    : content_type
+          "http method"     => @method,
+          "path"            => path,
+          "query string"    => query_string.hash,
+          "protocol"        => protocol,
+          "host"            => host,
+          "port"            => port,
+          "version"         => @version,
+          "query params"    => query_parameters.hash,
+          "path parameters" => path_parameters.hash,
+          "post parameters" => request_parameters.hash,
+          "content type"    => content_type
         }
       end
     end

--- a/src/amethyst/http/response.cr
+++ b/src/amethyst/http/response.cr
@@ -45,9 +45,9 @@ module Amethyst
           body = ""
         end
         {
-          "status"   :  status,
-          "response" :  body,
-          "version"  :  @version
+          "status"   => status,
+          "response" => body,
+          "version"  => @version
         }
       end
     end


### PR DESCRIPTION
When I ran `$ crystal spec` with Crystal 0.23.1, syntax errors occurred.

```
Syntax error in src/amethyst/http/request.cr:144: space not allowed between named argument name and ':'

          "http method"     : @method,
                             ^
```

```
$ crystal --version
Crystal 0.23.1 [e2a1389] (2017-07-13) LLVM 3.8.1
```