### PR TITLE
Remove duplicated message of running server

### DIFF
--- a/src/amethyst/base/app.cr
+++ b/src/amethyst/base/app.cr
@@ -56,7 +56,6 @@ module Amethyst
         host = "0.0.0.0"
         @port = port.to_i
         run_string = "[Amethyst #{VERSION}] serving application \"#{@name}\" at http://#{host}:#{@port}" #TODO move to Logger class
-        puts run_string
         App.logger.log_string run_string
         server = HTTP::Server.new host, port, @http_handler
         server.listen


### PR DESCRIPTION
When the server starts, duplicated messages are shown.

```
$ ./Foo
[Amethyst 0.1.7] serving application "Foo" at http://0.0.0.0:8080

   [Amethyst 0.1.7] serving application "Foo" at http://0.0.0.0:8080  
```
